### PR TITLE
Fix scrolling bug with contact me link

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -28,6 +28,9 @@ $(document).ready(function() {
         // Explicitly scroll to where the browser thinks the element
         // is, but apply the offset.
         $(href)[0].scrollIntoView();
-        window.scrollBy(0, -navOffset);
+        // Skip the offset for the last element. 
+        if (href != "#contact-me") {
+            window.scrollBy(0, -navOffset);
+        }
     });
 });


### PR DESCRIPTION
Currently, selecting the Contact Me nav pill will move the contact me section into view, but will not leave the pill selected. This is because the section is rather short, so that it does not take up the full view of the browser. When applying the nav offset, it technically moves back into the projects space. Turns out the offset is not necessary for the last section on the page in this case. 

I feel like this could be buggy if this section got longer. A better solution would be to check if the scroll is at the bottom, and if so do not apply the offset. 